### PR TITLE
Just fixing a typo in the AlbumController

### DIFF
--- a/module/Album/src/Album/Controller/AlbumController.php
+++ b/module/Album/src/Album/Controller/AlbumController.php
@@ -97,7 +97,7 @@ class AlbumController extends ActionController
         return array('album' => $this->albumTable->getAlbum($id));        
     }
 
-    public function setAlbums(AlbumTable $albumTable)
+    public function setAlbumTable(AlbumTable $albumTable)
     {
         $this->albumTable = $albumTable;
         return $this;


### PR DESCRIPTION
The setAlbums() function should probably be setAlbumTable() for consistency.  As it turns out the name doesn't matter, it's the parameter, but this might help someone not be confused, and it's consistent with the pdf.
