### PR TITLE
make the autoloader work

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,13 +3,7 @@ error_reporting(E_ALL|E_STRICT);
 chdir(dirname(__DIR__));
 require_once (getenv('ZF2_PATH') ?: 'vendor/ZendFramework/library') . '/Zend/Loader/AutoloaderFactory.php';
 
-Zend\Loader\AutoloaderFactory::factory(array('Zend\Loader\StandardAutoloader' => array(
-                'namespaces' => array(
-                    'Zend\Db' => realpath('vendor/Zend/Db'),
-                    'Zend' => realpath(getenv('ZF2_PATH').'/Zend'),
-                ),
-            ),));
-
+Zend\Loader\AutoloaderFactory::factory();
 
 $appConfig = include 'config/application.config.php';
 


### PR DESCRIPTION
Hi!

The autoloader wasn't really working, was complaining about not finding "Zend\Module\Listener\ListenerOptions", so I just changed the autoloader factory to be the same as in the ZendSkeletonApplication.
