### PR TITLE
Updating gitignore for local config files

### DIFF
--- a/config/autoload/.gitignore
+++ b/config/autoload/.gitignore
@@ -1,1 +1,1 @@
-local.config.php
+*local.php


### PR DESCRIPTION
Autoloaded config files end with either *global.php or *local.php,
so updating the gitignore to respect this.
